### PR TITLE
Add Pages 404 fallback and route fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Redirecting | RPI Bar Generator</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --color-bg: #090b10;
+      --color-panel: rgba(16, 20, 29, 0.88);
+      --color-border: rgba(255, 255, 255, 0.12);
+      --color-text: #f2f4f8;
+      --color-muted: rgba(242, 244, 248, 0.72);
+      --color-accent: #d6001c;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+      background:
+        radial-gradient(circle at top, rgba(214, 0, 28, 0.18), transparent 38%),
+        linear-gradient(180deg, #101520 0%, var(--color-bg) 68%);
+      color: var(--color-text);
+      font-family: "RPIGeist", system-ui, sans-serif;
+    }
+
+    .fallback_shell {
+      width: min(100%, 32rem);
+      padding: 1.5rem;
+      border: 1px solid var(--color-border);
+      border-radius: 1rem;
+      background: var(--color-panel);
+      backdrop-filter: blur(14px);
+    }
+
+    .fallback_kicker {
+      margin: 0 0 0.5rem;
+      font-size: 0.8rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-accent);
+    }
+
+    h1 {
+      margin: 0 0 0.75rem;
+      font-size: clamp(1.8rem, 4vw, 2.5rem);
+      line-height: 1;
+    }
+
+    p {
+      margin: 0;
+      color: var(--color-muted);
+      line-height: 1.55;
+    }
+
+    a {
+      color: var(--color-text);
+    }
+  </style>
+  <script>
+    (function loadPagesFallbackScript() {
+      const pathParts = window.location.pathname.split('/').filter(Boolean);
+      const firstPart = pathParts[0];
+      const rootSegments = new Set([
+        'generator',
+        'css',
+        'js',
+        'assets',
+        'references',
+        'third_party',
+        'frontify-block',
+        'attached_assets',
+        'index.html',
+        'marquee-ui.html',
+        'favicon.ico',
+        '404.html',
+        '.nojekyll'
+      ]);
+      const basePath = window.location.hostname.endsWith('.github.io') && firstPart && !rootSegments.has(firstPart)
+        ? `/${firstPart}/`
+        : '/';
+      window.__RPI_PAGES_BASE_PATH__ = basePath;
+      const script = document.createElement('script');
+      script.src = `${basePath}js/utils/pagesFallback.js`;
+      script.onload = function () {
+        const redirectUrl = window.PagesFallback && typeof window.PagesFallback.getPagesFallbackRedirectUrl === 'function'
+          ? window.PagesFallback.getPagesFallbackRedirectUrl(window.location.pathname, window.location.search, {
+            hostname: window.location.hostname
+          })
+          : basePath;
+
+        if (redirectUrl && redirectUrl !== window.location.pathname + window.location.search) {
+          window.location.replace(redirectUrl);
+        }
+      };
+      document.head.append(script);
+    })();
+  </script>
+</head>
+
+<body>
+  <main class="fallback_shell">
+    <p class="fallback_kicker">GitHub Pages Fallback</p>
+    <h1>Redirecting...</h1>
+    <p>
+      If this route does not recover automatically, return to
+      <a id="fallback-home-link" href="/">the homepage</a>.
+    </p>
+  </main>
+  <script>
+    const fallbackHomeLink = document.getElementById('fallback-home-link');
+    if (fallbackHomeLink && window.__RPI_PAGES_BASE_PATH__) {
+      fallbackHomeLink.setAttribute('href', window.__RPI_PAGES_BASE_PATH__);
+    }
+  </script>
+</body>
+
+</html>

--- a/js/generatorBootstrap.js
+++ b/js/generatorBootstrap.js
@@ -12,7 +12,26 @@
     });
   }
 
+  async function ensureGeneratorRoutes() {
+    if (window.GeneratorRoutes) {
+      return window.GeneratorRoutes;
+    }
+
+    await loadScript('js/utils/generatorRoutes.js');
+    return window.GeneratorRoutes || null;
+  }
+
   try {
+    const generatorRoutes = await ensureGeneratorRoutes();
+    const legacyGeneratorUrl = generatorRoutes
+      ? generatorRoutes.getLegacyGeneratorRedirectUrl(window.location.pathname, window.location.search)
+      : null;
+
+    if (legacyGeneratorUrl) {
+      window.location.replace(legacyGeneratorUrl);
+      return;
+    }
+
     const response = await fetch(sourcePath, { cache: 'no-cache' });
     if (!response.ok) {
       throw new Error(`Failed to load generator shell: ${response.status}`);

--- a/js/utils/generatorRoutes.js
+++ b/js/utils/generatorRoutes.js
@@ -75,6 +75,12 @@
     return normalized.startsWith('/') ? normalized : `/${normalized}`;
   }
 
+  function getComparablePathname(pathname) {
+    const value = typeof pathname === 'string' && pathname ? pathname : '/';
+    const normalized = value.replace(/\/{2,}/g, '/');
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+
   function toSearchParams(search) {
     if (search instanceof URLSearchParams) {
       return new URLSearchParams(search.toString());
@@ -101,6 +107,33 @@
 
   function buildPathFromSegments(segments) {
     return segments.length ? `/${segments.join('/')}/` : '/';
+  }
+
+  function buildUrlFromPathAndSearch(pathname, search) {
+    const params = toSearchParams(search);
+    const queryString = params.toString();
+    return queryString ? `${pathname}?${queryString}` : pathname;
+  }
+
+  function getGeneratorPathDetails(pathname) {
+    const normalizedPath = normalizePathname(pathname);
+    const parts = normalizedPath.split('/').filter(Boolean);
+    const generatorIndex = parts.indexOf('generator');
+
+    if (generatorIndex === -1) {
+      return {
+        generatorIndex,
+        rawStyle: '',
+        hasExplicitStyleSegment: false
+      };
+    }
+
+    const rawStyle = parts[generatorIndex + 1] || '';
+    return {
+      generatorIndex,
+      rawStyle,
+      hasExplicitStyleSegment: Boolean(rawStyle)
+    };
   }
 
   function getGeneratorRouteStyleFromPathname(pathname) {
@@ -134,17 +167,23 @@
   }
 
   function getLegacyGeneratorRedirectUrl(pathname, search) {
-    if (getGeneratorRouteStyleFromPathname(pathname) !== null) {
-      return null;
-    }
-
-    if (!hasGeneratorQueryState(search)) {
-      return null;
-    }
-
     const params = toSearchParams(search);
+    const { generatorIndex, rawStyle, hasExplicitStyleSegment } = getGeneratorPathDetails(pathname);
+    const currentUrl = buildUrlFromPathAndSearch(getComparablePathname(pathname), params);
+
+    if (generatorIndex !== -1) {
+      const style = normalizeStyleValue(hasExplicitStyleSegment ? rawStyle : (params.get('style') || 'solid'));
+      const canonicalUrl = buildGeneratorUrl(style, params, pathname);
+      return canonicalUrl !== currentUrl ? canonicalUrl : null;
+    }
+
+    if (!hasGeneratorQueryState(params)) {
+      return null;
+    }
+
     const style = normalizeStyleValue(params.get('style') || 'solid');
-    return buildGeneratorUrl(style, params, pathname);
+    const canonicalUrl = buildGeneratorUrl(style, params, pathname);
+    return canonicalUrl !== currentUrl ? canonicalUrl : null;
   }
 
   const api = {

--- a/js/utils/pagesFallback.js
+++ b/js/utils/pagesFallback.js
@@ -1,0 +1,193 @@
+(function (globalScope) {
+  const AVAILABLE_STYLE_VALUES = new Set([
+    'solid', 'ruler', 'ticker', 'binary', 'waveform', 'circles',
+    'numeric', 'morse', 'circles-gradient', 'gradient', 'grid',
+    'lines', 'point-connect', 'neural-network', 'triangle-grid', 'triangles',
+    'fibonacci-sequence', 'union', 'wave-quantum',
+    'runway', 'lunar', 'truss', 'music', 'graph'
+  ]);
+
+  const GENERATOR_QUERY_KEYS = new Set([
+    'style',
+    'colorMode',
+    'binaryText',
+    'morseText',
+    'numericValue',
+    'numericMode',
+    'circlesGradientVariant',
+    'gradientVariant',
+    'gridVariant',
+    'linesVariant',
+    'pointConnectVariant',
+    'neuralNetworkHiddenLayers',
+    'triangleGridVariant',
+    'trianglesVariant',
+    'rulerRepeats',
+    'rulerUnits',
+    'tickerRepeats',
+    'tickerRatio',
+    'tickerWidthRatio',
+    'waveformType',
+    'waveformFrequency',
+    'waveformSpeed',
+    'waveformEnvelope',
+    'waveformEnvelopeType',
+    'waveformEnvelopeWaves',
+    'waveformEnvelopeCenter',
+    'waveformEnvelopeBipolar',
+    'circlesMode',
+    'circlesFill',
+    'circlesDensity',
+    'circlesSizeVariation',
+    'circlesOverlap',
+    'trussFamily',
+    'trussSegments',
+    'trussThickness',
+    'staffNotes',
+    'staffTempo',
+    'staffInstrument',
+    'staffNoteShape',
+    'staffReverb',
+    'staffTremolo',
+    'pulseText',
+    'pulseIntensity',
+    'graphText',
+    'graphText2',
+    'graphText3',
+    'graphText4',
+    'graphText5',
+    'graphMulti',
+    'graphScale'
+  ]);
+
+  const ROOT_SITE_SEGMENTS = new Set([
+    'generator',
+    'css',
+    'js',
+    'assets',
+    'references',
+    'third_party',
+    'frontify-block',
+    'attached_assets',
+    'index.html',
+    'marquee-ui.html',
+    'favicon.ico',
+    '404.html',
+    '.nojekyll'
+  ]);
+
+  function normalizeStyleValue(style) {
+    if (style === 'staff') return 'music';
+    if (style === 'matrix') return 'solid';
+    return AVAILABLE_STYLE_VALUES.has(style) ? style : 'solid';
+  }
+
+  function normalizePathname(pathname) {
+    const value = typeof pathname === 'string' && pathname ? pathname : '/';
+    const normalized = value
+      .replace(/\/index\.html$/, '/')
+      .replace(/\/{2,}/g, '/');
+
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+
+  function toSearchParams(search) {
+    if (search instanceof URLSearchParams) {
+      return new URLSearchParams(search.toString());
+    }
+
+    return new URLSearchParams(typeof search === 'string' ? search.replace(/^\?/, '') : '');
+  }
+
+  function buildPathFromSegments(segments) {
+    return segments.length ? `/${segments.join('/')}/` : '/';
+  }
+
+  function inferPagesBasePath(pathname, hostname) {
+    const normalizedPathname = normalizePathname(pathname);
+    const pathParts = normalizedPathname.split('/').filter(Boolean);
+    const firstPart = pathParts[0];
+
+    if (!firstPart || ROOT_SITE_SEGMENTS.has(firstPart)) {
+      return '/';
+    }
+
+    if (typeof hostname === 'string' && hostname.endsWith('.github.io')) {
+      return buildPathFromSegments([firstPart]);
+    }
+
+    return '/';
+  }
+
+  function stripBasePath(pathname, hostname) {
+    const normalizedPathname = normalizePathname(pathname);
+    const basePath = inferPagesBasePath(normalizedPathname, hostname);
+
+    if (basePath === '/') {
+      return {
+        basePath,
+        relativePath: normalizedPathname
+      };
+    }
+
+    const normalizedBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+    const relativePath = normalizedPathname.startsWith(`${normalizedBasePath}/`)
+      ? normalizedPathname.slice(normalizedBasePath.length)
+      : normalizedPathname;
+
+    return {
+      basePath,
+      relativePath: relativePath.startsWith('/') ? relativePath : `/${relativePath}`
+    };
+  }
+
+  function hasGeneratorQueryState(search) {
+    const params = toSearchParams(search);
+    return Array.from(params.keys()).some(key => GENERATOR_QUERY_KEYS.has(key));
+  }
+
+  function getGeneratorFallbackUrl(basePath, relativeParts, search) {
+    const params = toSearchParams(search);
+    const requestedStyle = relativeParts[1] || params.get('style') || 'solid';
+    const style = normalizeStyleValue(requestedStyle);
+    params.delete('style');
+
+    const path = buildPathFromSegments([
+      ...basePath.split('/').filter(Boolean),
+      'generator',
+      style
+    ]);
+    const queryString = params.toString();
+    return queryString ? `${path}?${queryString}` : path;
+  }
+
+  function getPagesFallbackRedirectUrl(pathname, search, options = {}) {
+    const { hostname = '' } = options;
+    const params = toSearchParams(search);
+    const { basePath, relativePath } = stripBasePath(pathname, hostname);
+    const relativeParts = relativePath.split('/').filter(Boolean);
+
+    if (relativeParts[0] === 'generator') {
+      return getGeneratorFallbackUrl(basePath, relativeParts, params);
+    }
+
+    if (hasGeneratorQueryState(params)) {
+      return getGeneratorFallbackUrl(basePath, relativeParts, params);
+    }
+
+    return basePath;
+  }
+
+  const api = {
+    inferPagesBasePath,
+    getPagesFallbackRedirectUrl,
+    hasGeneratorQueryState,
+    normalizeStyleValue
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  globalScope.PagesFallback = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/references/project_status.md
+++ b/references/project_status.md
@@ -48,6 +48,14 @@ A web-based **Design Tool** integrated with RPI's central Brand Hub. It allows s
 *   [ ] **AI Exploration:** (Future) Event-specific background generation.
 
 ## 5. Recent Updates
+- **[2026-04-21] GitHub Pages 404 Fallback Added For Legacy And Bad Deep Links**:
+    - Audited the live GitHub Pages deployment at `https://tennitech.github.io/rpi-logo-generator/` and confirmed the intended primary routes still work directly under the real repo base path: `/`, `/generator/`, and valid `/generator/[style]/` pages all serve the expected shells and shared assets.
+    - Added a custom root `404.html` plus a dedicated Pages fallback utility so unsupported or legacy deep links such as `/generator/staff/`, `/generator/matrix/`, and unknown `/generator/[bar-style]/` paths now recover automatically into valid generator routes instead of stopping at GitHub's default 404 page.
+    - Preserved the marquee homepage as the default non-generator destination: unknown non-generator paths now redirect back to `/`, while bad legacy links that still carry generator query state continue to normalize into valid `/generator/[style]/` URLs under the same GitHub Pages base path.
+- **[2026-04-21] Legacy Generator Entry URLs Canonicalized To Style Routes**:
+    - Extended routing compatibility so old generator-first entry links like `/generator/` and `/generator/index.html` now redirect into the new `/generator/[style]/` structure instead of lingering on the pre-restructure base path.
+    - Preserved legacy `style` query handling on those generator entry links, mapping known aliases such as `staff` onto the current style slugs and falling back safely to `solid` when the requested style is missing or unknown.
+    - Moved the redirect check into the shared generator bootstrap as well so static wrapper pages normalize `index.html` variants and strip stale `style` query params before the generator shell loads.
 - **[2026-04-21] Waveform Preview Input Lag And Mobile Audio Teardown Fixed**:
     - Reduced live waveform preview cost by capping point density to an adaptive width-and-frequency-based sample budget and by moving envelope-state reads out of the per-vertex loop, which removes the worst slider and motion-toggle lag when waveform settings are pushed to their maximum values.
     - Fixed preview audio ownership so stopping audio now follows the actively playing preview type instead of the currently selected bar style; this resolves the waveform case where switching to another style could leave the old sound running.

--- a/tests/generatorRoutes.test.js
+++ b/tests/generatorRoutes.test.js
@@ -41,4 +41,12 @@ describe('generator route utils', () => {
     expect(getLegacyGeneratorRedirectUrl('/repo/marquee-ui.html', '?colorMode=red')).toBe('/repo/generator/solid/?colorMode=red');
     expect(getLegacyGeneratorRedirectUrl('/repo/generator/ticker/', '?colorMode=red')).toBeNull();
   });
+
+  test('canonicalizes legacy generator entry paths onto style routes', () => {
+    expect(getLegacyGeneratorRedirectUrl('/repo/generator/', '')).toBe('/repo/generator/solid/');
+    expect(getLegacyGeneratorRedirectUrl('/repo/generator/index.html', '?style=staff')).toBe('/repo/generator/music/');
+    expect(getLegacyGeneratorRedirectUrl('/repo/generator/index.html', '?style=unknown&colorMode=white')).toBe('/repo/generator/solid/?colorMode=white');
+    expect(getLegacyGeneratorRedirectUrl('/repo/generator/ticker/index.html', '?style=waveform&colorMode=red')).toBe('/repo/generator/ticker/?colorMode=red');
+    expect(getLegacyGeneratorRedirectUrl('/repo/generator/music/', '?style=staff')).toBe('/repo/generator/music/');
+  });
 });

--- a/tests/pagesFallback.test.js
+++ b/tests/pagesFallback.test.js
@@ -1,0 +1,48 @@
+const {
+  getPagesFallbackRedirectUrl,
+  inferPagesBasePath
+} = require('../js/utils/pagesFallback');
+
+describe('GitHub Pages fallback routing', () => {
+  test('infers the repository base path on GitHub Pages project sites', () => {
+    expect(inferPagesBasePath('/rpi-logo-generator/generator/ticker/', 'tennitech.github.io')).toBe('/rpi-logo-generator/');
+    expect(inferPagesBasePath('/generator/ticker/', 'example.com')).toBe('/');
+    expect(inferPagesBasePath('/css/style.css', 'tennitech.github.io')).toBe('/');
+  });
+
+  test('rewrites legacy generator aliases onto valid style routes', () => {
+    expect(
+      getPagesFallbackRedirectUrl('/rpi-logo-generator/generator/staff/', '?colorMode=red', {
+        hostname: 'tennitech.github.io'
+      })
+    ).toBe('/rpi-logo-generator/generator/music/?colorMode=red');
+
+    expect(
+      getPagesFallbackRedirectUrl('/rpi-logo-generator/generator/matrix/', '?colorMode=white', {
+        hostname: 'tennitech.github.io'
+      })
+    ).toBe('/rpi-logo-generator/generator/solid/?colorMode=white');
+  });
+
+  test('falls unknown generator routes back to the default solid style under the repo base path', () => {
+    expect(
+      getPagesFallbackRedirectUrl('/rpi-logo-generator/generator/not-a-style/', '?graphText=RPI', {
+        hostname: 'tennitech.github.io'
+      })
+    ).toBe('/rpi-logo-generator/generator/solid/?graphText=RPI');
+  });
+
+  test('sends non-generator 404s back to the homepage while preserving legacy generator query links', () => {
+    expect(
+      getPagesFallbackRedirectUrl('/rpi-logo-generator/does-not-exist', '', {
+        hostname: 'tennitech.github.io'
+      })
+    ).toBe('/rpi-logo-generator/');
+
+    expect(
+      getPagesFallbackRedirectUrl('/rpi-logo-generator/nope', '?style=ticker&tickerRepeats=55', {
+        hostname: 'tennitech.github.io'
+      })
+    ).toBe('/rpi-logo-generator/generator/ticker/?tickerRepeats=55');
+  });
+});


### PR DESCRIPTION
Add a custom 404.html and a new pagesFallback.js utility to recover legacy or bad deep links on GitHub Pages by inferring repo base paths and canonicalizing generator routes. Update generatorRoutes.js with normalization helpers and URL-building logic so legacy generator entry URLs and query-state links redirect to canonical /generator/[style]/ routes. Load generator route redirects early in generatorBootstrap.js to avoid loading the shell for legacy URLs. Add tests for fallback and generator route behavior and document the change in project_status.md.